### PR TITLE
Force a past date range for archived events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4567,9 +4567,14 @@
       }
     },
     "date-fns": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.18.0.tgz",
+      "integrity": "sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw=="
+    },
+    "dateformat": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
+      "integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q=="
     },
     "debug": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "axios": "^0.21.1",
+    "date-fns": "^2.18.0",
+    "dateformat": "^4.5.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-html-parser": "^2.0.2",

--- a/src/components/PastMEHeaders.jsx
+++ b/src/components/PastMEHeaders.jsx
@@ -9,9 +9,7 @@ const PastMEHeaders = (props) => {
   return (
     <TableHead>
       <TableRow>
-        <TableHeadCell key="StatusHeader" className="order-by">
-          Date
-        </TableHeadCell>
+        <TableHeadCell key="StatusHeader">Date</TableHeadCell>
         <TableHeadCell key="AgencyHeader">Name</TableHeadCell>
         <TableHeadCell key="InformationHeader">Details</TableHeadCell>
       </TableRow>

--- a/src/components/PastMEHeaders.jsx
+++ b/src/components/PastMEHeaders.jsx
@@ -9,7 +9,9 @@ const PastMEHeaders = (props) => {
   return (
     <TableHead>
       <TableRow>
-        <TableHeadCell key="StatusHeader">Date</TableHeadCell>
+        <TableHeadCell key="StatusHeader" className="order-by">
+          Date
+        </TableHeadCell>
         <TableHeadCell key="AgencyHeader">Name</TableHeadCell>
         <TableHeadCell key="InformationHeader">Details</TableHeadCell>
       </TableRow>

--- a/src/startup.js
+++ b/src/startup.js
@@ -2,7 +2,21 @@ import { Config } from "@baltimorecounty/javascript-utilities";
 
 const { setConfig } = Config;
 
-const apiPath = "api/hub/structuredContent/Events";
+const InitializeDateValues = () => {
+  var dateFormat = require("dateformat");
+
+  const startDate = new Date().setFullYear(new Date().getFullYear() - 2);
+  const endDate = new Date().setDate(new Date().getDate() - 1);
+
+  const startDateFormat = dateFormat(startDate, "mm/dd/yyyy");
+  const endDateFormat = dateFormat(endDate, "mm/dd/yyyy");
+
+  var fromToDateFormat = startDateFormat + "," + endDateFormat;
+
+  return fromToDateFormat;
+};
+
+const apiPath = `api/hub/structuredContent/Events?${InitializeDateValues()}`;
 const testApiRoot = `https://testservices.baltimorecountymd.gov/${apiPath}`;
 const prodApiRoot = `https://services.baltimorecountymd.gov/${apiPath}`;
 

--- a/src/startup.js
+++ b/src/startup.js
@@ -16,7 +16,7 @@ const InitializeDateValues = () => {
   return fromToDateFormat;
 };
 
-const apiPath = `api/hub/structuredContent/Events?${InitializeDateValues()}`;
+const apiPath = `api/hub/structuredContent/Events?filterdate=${InitializeDateValues()}`;
 const testApiRoot = `https://testservices.baltimorecountymd.gov/${apiPath}`;
 const prodApiRoot = `https://services.baltimorecountymd.gov/${apiPath}`;
 


### PR DESCRIPTION
So the events endpoint had to change to accept a date range. In order for this to be past events we now have to force the 2 year time frame that had been originally hard coded in the service.